### PR TITLE
Use LGTM App token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build
@@ -15,19 +12,27 @@ jobs:
       startsWith(github.event.issue.title, 'Release:') &&
       !contains(github.event.issue.labels.*.name, 'locked') &&
       contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Generate LGTM App token
+        id: lgtm-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: CHANGELOG
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Set up Go 1.25
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
+          cache: false
         id: go
 
       - name: Install yq
@@ -84,15 +89,15 @@ jobs:
       - name: Prepare git
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
-          git config --global user.name "1gtm"
-          git config --global user.email "1gtm@appscode.com"
+          git config --global user.name "lgtm-app[bot]"
+          git config --global user.email "264684964+lgtm-app[bot]@users.noreply.github.com"
           git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Verify PR is from same repo (not a fork)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           head_repo=$(gh pr view ${{ github.event.issue.number }} \
             --json headRepositoryOwner,headRepository \
@@ -105,7 +110,7 @@ jobs:
       - name: Release
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,11 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           git config --global user.name "lgtm-app[bot]"
           git config --global user.email "264684964+lgtm-app[bot]@users.noreply.github.com"
-          git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Verify PR is from same repo (not a fork)
         env:
@@ -109,7 +108,6 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}


### PR DESCRIPTION
## Summary
- Mint a short-lived token from the LGTM GitHub App via `actions/create-github-app-token`, scoped to this repo with `contents`/`issues`/`pull-requests` write, and use it in place of `secrets.GITHUB_TOKEN` in the release workflow.
- Drop the now-unused top-level/job-level `permissions:` blocks (the default `GITHUB_TOKEN` is only used by `actions/checkout` for a read-only fetch).
- Bump runner to `ubuntu-24.04`, add `cache: false` to `setup-go` (no `go.sum` in this repo), and align git author/committer with the LGTM bot identity (`lgtm-app[bot]`).

## Test plan
- [ ] Confirm `LGTM_APP_CLIENT_ID` and `LGTM_APP_PRIVATE_KEY` are set as repo (or org) secrets and the LGTM App is installed on `kubevault/CHANGELOG` with Contents/Issues/Pull requests write.
- [ ] Trigger the workflow by commenting `/release` on a release tracker PR and verify: token mints, PR fork-check passes, release-automaton runs, README/release-table push lands on the branch authored & committed by `lgtm-app[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)